### PR TITLE
Changed path separator in `src_paths` when copying multiple files

### DIFF
--- a/tasks/bower.js
+++ b/tasks/bower.js
@@ -92,7 +92,7 @@ module.exports = function(grunt) {
 
               } else {
                 src_paths.forEach(function(src_path) {
-                  var file_name = src_path.split(path.sep).pop();
+                  var file_name = src_path.split(/[\\\/]/).pop();
                   var ext_name = file_name.split('.').pop();
                   var dest_dir = package_dests[ext_name] ||
                     dests[ext_name] || package_dest || dest;


### PR DESCRIPTION
Bower components may have file paths in `main` field in different formats, including `\` and `/` path separators in different cases. We can't always rely just on `path.sep` when splitting the file name prior to copying. Broken use case: with current version of `grunt-bower` copying of Twitter Bootstrap in Windows environment doesn't work, such an error is thrown:

```
Fail to copy C:/Home/edumoko/bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.ttf for bootstrap!
```

Changing the path separator to more common regexp rather than `path.sep` solves the problem.
