### PR TITLE
Add new option `expand`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,59 @@ bower: {
 }
 ```
 
+If you want the exported files to be organized by package, use `expand` option. For example, such config will result in the file structure like this:
+
+```javascript
+bower: {
+  dev: {
+    dest: 'public/vendor/',
+    options: {
+      expand: true
+    }
+  }
+}
+```
+```
+/public
+  /vendor
+    /package1
+	  package1_file1.js
+	  package1_file2.js
+	  package1.css
+	/package2
+	  package2.js
+	  package2.css
+```
+
+Or organized by file type in addition:
+	
+```javascript
+bower: {
+  dev: {
+    dest: 'public/',
+	js_dest: 'public/js/'
+	css_dest: 'public/css/',
+    options: {
+      expand: true
+    }
+  }
+}
+```
+```
+/public
+  /js
+    /package1
+	  package1_file1.js
+	  package1_file2.js
+	/package2
+	  package2.js
+  /css
+    /package1
+	  package1.css
+	/package2
+	  package2.css
+```  
+
 
 ## Change Logs
 - Apr 09, 2014 v0.10.0

--- a/tasks/bower.js
+++ b/tasks/bower.js
@@ -95,7 +95,7 @@ module.exports = function(grunt) {
 
               if(src_paths.length == 1) {
                 var ext_name = dest_file_name.split('.').pop();
-                dest_file_path = path.join(dests[ext_name] || dest, dest_file_name);
+                dest_file_path = path.join(dests[ext_name] || dest, options.expand ? lib_name : '', dest_file_name);
                 grunt.file.copy(src_paths[0], dest_file_path);
                 log(src_paths[0].cyan + ' copied.\n');
 
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
                   var dest_dir = package_dests[ext_name] ||
                     dests[ext_name] || package_dest || dest;
 
-                  dest_file_path = path.join(dest_dir, file_name);
+                  dest_file_path = path.join(dest_dir, options.expand ? lib_name : '', file_name);
                   try{
                     grunt.file.copy(src_path, dest_file_path);
                     log(src_path.cyan + ' copied.\n');


### PR DESCRIPTION
An option for organizing the file structure by package rather than placing them all in one directory. Useful when some filenames could intersect with each other.

``` javascript
bower: {
  dev: {
    dest: 'public/vendor/',
    options: {
      expand: true
    }
  }
}
```

```
/public
  /vendor
    /package1
      package1_file1.js
      package1_file2.js
      package1.css
    /package2
      package2.js
      package2.css
```

Or organized by file type in addition:

``` javascript
bower: {
  dev: {
    dest: 'public/',
    js_dest: 'public/js/'
    css_dest: 'public/css/',
    options: {
      expand: true
    }
  }
}
```

```
/public
  /js
    /package1
      package1_file1.js
      package1_file2.js
    /package2
      package2.js
  /css
    /package1
      package1.css
    /package2
      package2.css
```
