### PR TITLE
Replace everything before and expanded_dir to get file name

### DIFF
--- a/tasks/bower.js
+++ b/tasks/bower.js
@@ -125,7 +125,7 @@ module.exports = function(grunt) {
               }).each(function(src_path) {
 
                 if (!flatten && expanded_dir && src_path.indexOf(expanded_dir) > -1) {
-                  file_name = src_path.replace(expanded_dir, '');
+                  file_name = src_path.replace(new RegExp(".*" + expanded_dir), '');
                 } else {
                   file_name = src_path.split(/[\\\/]/).pop();
                 }


### PR DESCRIPTION
I had an issue in Windows where ```src_path``` contained the full path to the source file, resulting in an incorrect ```file_name```.
eg
```src_path``` was  ```C:/xampp/htdocs/myproject/bower_components/jquery/dist/jquery.js```
```file_name``` was ```C:/xampp/htdocs/myproject//dist/jquery.js```

Replacing everything before ```expanded_dir``` fixed the issue...... not sure if that's the best place to do it