### PR TITLE
Fix path delimiters bug in windows environment

### DIFF
--- a/tasks/bower.js
+++ b/tasks/bower.js
@@ -120,7 +120,7 @@ module.exports = function(grunt) {
               _(src_paths).chain().map(function(src_path) {
                 return grunt.file.expand(src_path);
               }).flatten().map(function(src_path) {
-                var baseDirRegex = new RegExp(bower.config.cwd + '/?');
+                var baseDirRegex = new RegExp(bower.config.cwd.replace(/\\/g,'[\\\/]') + '/?');
                 return src_path.replace(baseDirRegex, '');
               }).each(function(src_path) {
 


### PR DESCRIPTION
This will fix an issue with Windows incompatibility. It was because of incorrectly parsed paths in `baseDirRegex` due to different path delimiters: `/` instead of `\`. With this patch now everything works as expected.

Fixes #45 
Fixes #44 
