### PR TITLE
grunt-bower failed with newer versions of grunt due to changes in lodash API

### DIFF
--- a/tasks/bower.js
+++ b/tasks/bower.js
@@ -119,14 +119,12 @@ module.exports = function(grunt) {
               if(!flatten) {
                 expanded_dir = grunt.file.expand(path.join(bower.config.directory, lib_name)).shift();
               }
-
-              _(src_paths).chain().map(function(src_path) {
+              _.chain(src_paths).map(function(src_path) {
                 return grunt.file.expand(src_path);
               }).flatten().map(function(src_path) {
                 var baseDirRegex = new RegExp(bower.config.cwd.replace(/\\/g,'[\\\/]') + '/?');
                 return src_path.replace(baseDirRegex, '');
               }).each(function(src_path) {
-
                 if (!flatten && expanded_dir && src_path.indexOf(expanded_dir) > -1) {
                   file_name = src_path.replace(expanded_dir, '');
                 } else {
@@ -171,7 +169,7 @@ module.exports = function(grunt) {
                       src_path.yellow + (' for ').red +
                       lib_name.yellow + ('!\n').red);
                 }
-              });
+              }).value();
             });
           } catch (err) {
             log(err.stack);

--- a/tasks/lib/helpers.js
+++ b/tasks/lib/helpers.js
@@ -37,6 +37,11 @@ exports.init = function(grunt) {
   var path = require('path');
   var _ = grunt.utils ? grunt.utils._ : grunt.util._;
 
+  // Hacky fix for lodash v3/v4 API change, see https://github.com/angular-ui/angular-google-maps/issues/1682
+  if( typeof _.object === 'undefined' ) {
+    _.object = _.zipObject;
+  }
+  
   exports.getLibFilenames = function(main_path, components_path, lib_name) {
     // In Nodejs 0.8.0, existsSync moved from path -> fs.
     var existsSync = fs.existsSync || path.existsSync;


### PR DESCRIPTION
There were two issues that needed fixing: lodash3 and above only perform certain chained commands when the chain is executed, which requires a call to e.g. `value()`. Secondly, `_.object` was deprecated and needs to be aliased to `_.zipObject`